### PR TITLE
Enhancement/module options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,3 +13,13 @@ test_unit:
   script:
     - npm install
     - npm run test:unit
+
+pages:
+  stage: deploy
+  script:
+    - echo 'Deploying public folder...'
+  artifacts:
+    paths:
+      - public
+  only:
+    - gh-pages

--- a/.stories/index.vue
+++ b/.stories/index.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0">
-      <a class="navbar-brand col-sm-3 col-md-2 mr-0" href="#" @click="storiesHome(story)">Stories</a>
+      <a
+        class="navbar-brand col-sm-3 col-md-2 mr-0"
+        href="#"
+        @click="storiesHome(story)"
+        >Stories</a
+      >
       <ul class="navbar-nav px-3">
         <li class="nav-item text-nowrap">
           <a class="nav-link" href="/">Back to APP</a>
@@ -11,28 +16,55 @@
     <div class="container-fluid">
       <div class="row">
         <nav class="col-md-2 d-none d-md-block bg-light sidebar">
-          <div class="sidebar-sticky">  
-          <b-card no-body class="mb-1 nav flex-column" v-for="story in stories" :key="story.name">
-            <b-card-header header-tag="header" class="p-1" role="tab">
-              <b-button block @click="toggleVisibility(story)" variant="info">
-                <nuxt-link :to="story.path" style="color:white;">{{ story.name }}</nuxt-link></b-button>
-            </b-card-header>
-            <b-collapse :id="storyId(story.name)" :visible="story.visible" accordion="my-accordion" role="tabpanel">
-              <b-card-body>
-                <b-card-text>
-                  <b-nav vertical class="story-child-nav-item" v-for="child in story.children" :key="child.name">
-                    <b-list-group>
-                      <b-list-group-item :active="childActive(child)" @click="showChild(child)"> 
-                        {{ cleanName(child.name) }}
-                      </b-list-group-item>
-                      <b-list-group-item>Child 2 (add file to {{story.name}} dir</b-list-group-item>
-                      <b-list-group-item>Child 3 (add file to {{story.name}} dir</b-list-group-item>
-                    </b-list-group>
-                  </b-nav>
-                </b-card-text>
-              </b-card-body>
-            </b-collapse>
-          </b-card>
+          <div class="sidebar-sticky">
+            <b-card
+              v-for="story in stories"
+              :key="story.name"
+              no-body
+              class="mb-1 nav flex-column"
+            >
+              <b-card-header header-tag="header" class="p-1" role="tab">
+                <b-button block variant="info" @click="toggleVisibility(story)">
+                  <nuxt-link :to="story.path" style="color:white;">{{
+                    story.name
+                  }}</nuxt-link></b-button
+                >
+              </b-card-header>
+              <b-collapse
+                :id="storyId(story.name)"
+                :visible="story.visible"
+                accordion="my-accordion"
+                role="tabpanel"
+              >
+                <b-card-body>
+                  <b-card-text>
+                    <b-nav
+                      v-for="child in story.children"
+                      :key="child.name"
+                      vertical
+                      class="story-child-nav-item"
+                    >
+                      <b-list-group>
+                        <b-list-group-item
+                          :active="childActive(child)"
+                          @click="showChild(child)"
+                        >
+                          {{ cleanName(child.name) }}
+                        </b-list-group-item>
+                        <b-list-group-item
+                          >Child 2 (add file to
+                          {{ story.name }} dir</b-list-group-item
+                        >
+                        <b-list-group-item
+                          >Child 3 (add file to
+                          {{ story.name }} dir</b-list-group-item
+                        >
+                      </b-list-group>
+                    </b-nav>
+                  </b-card-text>
+                </b-card-body>
+              </b-collapse>
+            </b-card>
           </div>
         </nav>
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 pt-3 px-4">

--- a/.stories/index/Card.vue
+++ b/.stories/index/Card.vue
@@ -1,30 +1,32 @@
 <template>
   <div class="card-container">
-    These are example cards! Taken from bootstrap-vue docs. You may want to stash this code in your custom components (@/components directory)
-    When you edit those components, hot module reloading should let you see the stories update too!
+    These are example cards! Taken from bootstrap-vue docs. You may want to
+    stash this code in your custom components (@/components directory) When you
+    edit those components, hot module reloading should let you see the stories
+    update too!
     <b-card-group deck>
-    <b-card
-      header="featured"
-      header-tag="header"
-      footer="Card Footer"
-      footer-tag="footer"
-      title="Title"
-    >
-      <b-card-text>Header and footers using props.</b-card-text>
-      <b-button href="#" variant="primary">Go somewhere</b-button>
-    </b-card>
+      <b-card
+        header="featured"
+        header-tag="header"
+        footer="Card Footer"
+        footer-tag="footer"
+        title="Title"
+      >
+        <b-card-text>Header and footers using props.</b-card-text>
+        <b-button href="#" variant="primary">Go somewhere</b-button>
+      </b-card>
 
-    <b-card title="Title" header-tag="header" footer-tag="footer">
-      <template v-slot:header>
-        <h6 class="mb-0">Header Slot</h6>
-      </template>
-      <b-card-text>Header and footers using slots.</b-card-text>
-      <b-button href="#" variant="primary">Go somewhere</b-button>
-      <template v-slot:footer>
-        <em>Footer Slot</em>
-      </template>
-    </b-card>
-  </b-card-group>
+      <b-card title="Title" header-tag="header" footer-tag="footer">
+        <template v-slot:header>
+          <h6 class="mb-0">Header Slot</h6>
+        </template>
+        <b-card-text>Header and footers using slots.</b-card-text>
+        <b-button href="#" variant="primary">Go somewhere</b-button>
+        <template v-slot:footer>
+          <em>Footer Slot</em>
+        </template>
+      </b-card>
+    </b-card-group>
   </div>
 </template>
 

--- a/.stories/index/Chart.vue
+++ b/.stories/index/Chart.vue
@@ -1,6 +1,10 @@
 <template>
-  <div><h3>Chart Story. Example Chart</h3>
-  <div class="component-container">Place your component here. I.e., <pre>&lt;your-chart>&lt;/your-chart&gt;</pre></div>
+  <div>
+    <h3>Chart Story. Example Chart</h3>
+    <div class="component-container">
+      Place your component here. I.e.,
+      <pre>&lt;your-chart>&lt;/your-chart&gt;</pre>
+    </div>
   </div>
 </template>
 

--- a/.stories/index/Logo.vue
+++ b/.stories/index/Logo.vue
@@ -2,7 +2,11 @@
   <div>
     <h3>Logo</h3>
     <logo></logo>
-    <div>^^ this is usually added to your components directory when you first create your Nuxt app. If you want to tweak it, you can see the live changes here</div>
+    <div>
+      ^^ this is usually added to your components directory when you first
+      create your Nuxt app. If you want to tweak it, you can see the live
+      changes here
+    </div>
     <nuxt-child></nuxt-child>
   </div>
 </template>

--- a/.stories/index/Logo/LogoChild.vue
+++ b/.stories/index/Logo/LogoChild.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="logo-child"> This is Logo's child </div>
+  <div class="logo-child">This is Logo's child</div>
 </template>
 
 <script>

--- a/modules/stories.module.js
+++ b/modules/stories.module.js
@@ -14,7 +14,11 @@ const glob = pify(Glob)
 
 /* eslint-disable no-console */
 module.exports = function(moduleOptions) {
-  const { forceBuild, storiesDir = '.stories' } = moduleOptions
+  const {
+    forceBuild,
+    storiesDir = '.stories',
+    storiesAnchor = storiesDir
+  } = moduleOptions
 
   if (process.env.NODE_ENV !== 'development' && !forceBuild) return
 
@@ -40,7 +44,7 @@ module.exports = function(moduleOptions) {
         )
         return
       }
-      storyRoutes.name = storiesDir
+      storyRoutes.name = storiesAnchor
       storyRoutes.path = `/${storyRoutes.name}`
       routes.push(storyRoutes)
     })
@@ -51,7 +55,8 @@ module.exports = function(moduleOptions) {
     src: pResolve(__dirname, 'stories.plugin.js'),
     fileName: 'nuxt-stories.js',
     options: {
-      storiesDir
+      storiesDir,
+      storiesAnchor
     }
   })
 }

--- a/modules/stories.module.js
+++ b/modules/stories.module.js
@@ -4,15 +4,16 @@
    Licensed under MIT (https://github.com/richardeschloss/nuxt-stories/blob/master/LICENSE)
  */
 
-import consola from 'consola'
-import Glob from 'glob'
-import pify from 'pify'
-import { createRoutes } from '@nuxt/utils'
+const { resolve: pResolve } = require('path')
+const consola = require('consola')
+const Glob = require('glob')
+const pify = require('pify')
+const { createRoutes } = require('@nuxt/utils')
 
 const glob = pify(Glob)
 
 /* eslint-disable no-console */
-export default function(moduleOptions) {
+module.exports = function(moduleOptions) {
   const { forceBuild, storiesDir = '.stories' } = moduleOptions
 
   if (process.env.NODE_ENV !== 'development' && !forceBuild) return
@@ -44,4 +45,15 @@ export default function(moduleOptions) {
       routes.push(storyRoutes)
     })
   })
+
+  this.addPlugin({
+    ssr: false,
+    src: pResolve(__dirname, 'stories.plugin.js'),
+    fileName: 'nuxt-stories.js',
+    options: {
+      storiesDir
+    }
+  })
 }
+
+module.exports.meta = require('../package.json')

--- a/modules/stories.plugin.js
+++ b/modules/stories.plugin.js
@@ -1,0 +1,11 @@
+function nuxtStories() {
+  const pluginOptions = <%= JSON.stringify(options) %>
+
+  return Object.freeze({
+    options: pluginOptions
+  })
+}
+
+export default function(context, inject) {
+  inject('nuxtStories', nuxtStories)
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,7 +35,8 @@ module.exports = {
     // Doc: https://github.com/nuxt-community/eslint-module
     '@nuxtjs/eslint-module',
     // Doc: https://github.com/richardeschloss/nuxt-stories
-    'modules/stories.module' // Enabled for dev mode only
+    // 'modules/stories.module' // Enabled for dev mode only
+    ['modules/stories.module', { storiesDir: '.stories' }]
   ],
   /*
    ** Nuxt.js modules
@@ -57,6 +58,7 @@ module.exports = {
     hardSource: true
   },
   generate: {
-    routes: ['/.stories']
+    routes: ['/.stories'],
+    dir: 'public'
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,7 +12,7 @@
         <b-button
           class="button--grey"
           style="color:lightyellow;"
-          @click="toStories(story)"
+          @click="toStories()"
         >
           Nuxt Stories: See it in action!
         </b-button>
@@ -37,7 +37,9 @@ export default {
   },
   methods: {
     toStories() {
-      this.$router.push('/.stories')
+      const { options } = this.$nuxtStories({})
+      const { storiesAnchor } = options
+      this.$router.push(`/${storiesAnchor}`)
     }
   }
 }

--- a/test/specs/Module.spec.js
+++ b/test/specs/Module.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { readdirSync } from 'fs'
 import path from 'path'
 import test from 'ava'
 import NuxtStoriesMod from '@/modules/stories.module'
@@ -6,23 +7,47 @@ import NuxtStoriesMod from '@/modules/stories.module'
 const srcDir = path.resolve('.')
 
 test('Story routes created ok', (t) => {
+  const storiesDir = '.stories'
+  const forceBuild = true
+  const modOptions = {
+    forceBuild,
+    storiesDir
+  }
+  const files = readdirSync(storiesDir)
+  const storiesRoot = files[0]
   return new Promise((resolve) => {
+    let doneCnt = 0
+    const expCnt = 2
+    function handleDone() {
+      if (++doneCnt === expCnt) resolve()
+    }
     const sampleRoutes = []
     const modContainer = {
       extendRoutes(fn) {
         fn(sampleRoutes, path.resolve)
         const storyRoute = sampleRoutes[0]
         console.log('storyRoute', storyRoute)
-        t.is(storyRoute.name, '.stories')
-        t.is(storyRoute.path, '/.stories')
-        t.is(storyRoute.component, path.resolve(srcDir, '.stories/index.vue'))
-        t.is(storyRoute.chunkName, '.stories/index')
+        t.is(storyRoute.name, storiesDir)
+        t.is(storyRoute.path, `/${storiesDir}`)
+        t.is(
+          storyRoute.component,
+          path.resolve(srcDir, `${storiesDir}/${storiesRoot}.vue`)
+        )
+        t.is(storyRoute.chunkName, `${storiesDir}/${storiesRoot}`)
         t.truthy(storyRoute.children)
         t.true(storyRoute.children.length > 0)
-        resolve()
+        handleDone()
       }
     }
     const simpleNuxt = {
+      addPlugin({ src, fileName, options }) {
+        console.log('options', options)
+        t.is(src, path.resolve(srcDir, 'modules/stories.plugin.js'))
+        t.is(fileName, 'nuxt-stories.js')
+        t.is(options.storiesDir, storiesDir)
+        t.is(options.storiesAnchor, storiesDir)
+        handleDone()
+      },
       options: {
         srcDir,
         modules: []
@@ -38,6 +63,6 @@ test('Story routes created ok', (t) => {
       },
       registerMod: NuxtStoriesMod
     }
-    simpleNuxt.registerMod({ forceBuild: true })
+    simpleNuxt.registerMod(modOptions)
   })
 })

--- a/test/specs/Plugin.spec.js
+++ b/test/specs/Plugin.spec.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+import fs from 'fs'
+import path from 'path'
+import test from 'ava'
+import template from 'lodash/template'
+
+test('Stories plugin', async (t) => {
+  const src = path.resolve('./modules/stories.plugin.js')
+  const tmpFile = path.resolve('./tmp.compiled.js')
+  const content = fs.readFileSync(src, 'utf-8')
+  const pluginOptions = {
+    storiesDir: '.stories',
+    storiesAnchor: '.stories'
+  }
+
+  try {
+    const compiled = template(content)
+    const pluginJs = compiled({ options: pluginOptions })
+    fs.writeFileSync(tmpFile, pluginJs)
+    const { default: Plugin } = await import(tmpFile).catch((err) => {
+      console.error('Err importing plugin', err)
+      t.fail()
+    })
+
+    Plugin({}, (label, NuxtStories) => {
+      const { options } = NuxtStories({})
+      t.is(label, 'nuxtStories')
+      t.is(options.storiesDir, pluginOptions.storiesDir)
+      t.is(options.storiesAnchor, pluginOptions.storiesAnchor)
+      fs.unlinkSync(tmpFile)
+    })
+  } catch (e) {
+    console.error('Could not compile plugin :(', e)
+    t.fail()
+  }
+})


### PR DESCRIPTION
- Addresses issue #3. moduleOptions now accepts:
1. "storiesDir" which defaults to ".stories". This is the directory containing the stories pages
2. "storiesAnchor" which defaults to whatever "storiesDir" is. This is where the story *routes* start. Don't prefix wtih "/". Module will handle that.
  
- Updated automated tests
- Added a plugin to help with future development (by holding on to nuxtStories config and options at the story app level)
- Also linted code.