### PR TITLE
Fixed hmr issue I think

### DIFF
--- a/.stories/index/Markdown.vue
+++ b/.stories/index/Markdown.vue
@@ -10,6 +10,7 @@
 
       * Bullet 1
       * Bullet 2
+      * Bullet 3
 
       ### Here is a component:
 


### PR DESCRIPTION
In the markdown component, I have one [hidden] div for the raw markdown, and another for the compiled output. This seems to have helped (reloading appears to be triggered twice: once for the change made to the html file, and then when the div's inner html is updated).