### PR TITLE
Issue/84

### DIFF
--- a/lib/module.register.js
+++ b/lib/module.register.js
@@ -266,6 +266,7 @@ export const register = Object.freeze({
       }
 
       if (markdown) {
+        story.path = decodeURIComponent(story.path)
         story.mdPath = `${story.path}.md`
         const contents = readFileSync(storyPath(story.mdPath))
         const { frontMatter } = Markdown.parse(contents)


### PR DESCRIPTION
For some reason, Nuxt's route builder builds the paths with HTML entities (but not always, depends if the code is running in node_modules or not) which made this problem difficult to find during development. Now on boot, the HTML entities are stripped and things seem to work.