### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,7 +5,7 @@ import Json from 'vue-json-pretty'
 import TestRunner from './components/TestRunner.js'
 import TestCoverage from './components/TestCoverage.js'
 import Readme from './components/Readme.js'
-import { defineNuxtPlugin, useState } from '#app'
+import { defineNuxtPlugin, useState } from '#imports'
 
 const debug = Debug('nuxt-stories')
 

--- a/test/specs/Fetch.spec.js
+++ b/test/specs/Fetch.spec.js
@@ -1,7 +1,7 @@
 import http from 'http'
 import ava from 'ava'
 import Fetch, { initTransformers } from '#root/lib/utils/fetch.js'
-import { useState } from '#app'
+import { useState } from '#imports'
 
 const { serial: test, before, after } = ava
 

--- a/test/specs/StoryFactory.spec.js
+++ b/test/specs/StoryFactory.spec.js
@@ -3,7 +3,7 @@ import ava from 'ava'
 import { compile, createApp, h } from 'vue'
 import BrowserEnv from 'browser-env'
 import StoryFactory, { LoadDeps } from '#root/lib/utils/storyFactory.js'
-import { useState } from '#app'
+import { useState } from '#imports'
 BrowserEnv({})
 
 const { serial: test } = ava


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.